### PR TITLE
Fix bug where bwt sendsd 2017 headers to electrum

### DIFF
--- a/src/electrum/server.rs
+++ b/src/electrum/server.rs
@@ -120,7 +120,7 @@ impl Connection {
         // drop unknown heights (from the specs: "If the chain has not extended sufficiently far,
         // only the available headers will be returned. If more headers than max were requested at
         // most max will be returned.")
-        let max_height = cmp::min(start_height + count, self.query.get_tip_height()?);
+        let max_height = cmp::min(start_height + count - 1, self.query.get_tip_height()?);
 
         // TODO use batch rpc when available in rust-bitcoincore-rpc
         let headers: Vec<String> = (start_height..=max_height)
@@ -129,6 +129,7 @@ impl Connection {
                 self.query.get_header_hex(&blockhash)
             })
             .collect::<Result<Vec<_>>>()?;
+        assert!(headers.len() <= count as usize);
 
         let mut result = json!({
             "count": headers.len(),


### PR DESCRIPTION
It was causing this error in electrum 4.0.9:
```

E/i | interface.[localhost:50001] | Exception in wrapper_func: RequestCorrupted('expected 2016 headers but only got 2017')
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/electrum/util.py", line 1056, in wrapper
    return await func(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 481, in wrapper_func
    return await func(self, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 505, in run
    await self.open_session(ssl_context)
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 649, in open_session
    await group.spawn(self.monitor_connection)
  File "/usr/lib/python3.9/site-packages/aiorpcx/curio.py", line 242, in __aexit__
    await self.join()
  File "/usr/lib/python3.9/site-packages/aiorpcx/curio.py", line 211, in join
    raise task.exception()
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 703, in run_fetch_blocks
    await self._process_header_at_tip()
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 720, in _process_header_at_tip
    await self.sync_until(height)
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 729, in sync_until
    could_connect, num_headers = await self.request_chunk(height, next_height)
  File "/usr/lib/python3.9/site-packages/electrum/interface.py", line 613, in request_chunk
    raise RequestCorrupted(f"expected {size} headers but only got {res['count']}")
electrum.interface.RequestCorrupted: expected 2016 headers but only got 2017
```